### PR TITLE
SmokeTests is missing a namespace

### DIFF
--- a/tests/Todo.Dapper.Tests/SmokeTests.cs
+++ b/tests/Todo.Dapper.Tests/SmokeTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
I tried this with the latest .NET 6 RC1 nightly
build, so I didn't see any implicit namespace
that would fix this.