### PR TITLE
Added ModelBinder<T> for MVC model binding

### DIFF
--- a/src/MinimalApiPlayground/Program.cs
+++ b/src/MinimalApiPlayground/Program.cs
@@ -19,6 +19,10 @@ builder.Services.AddSqlite<TodoDb>(connectionString)
                 .AddDatabaseDeveloperPageExceptionFilter();
 builder.Services.AddParameterBinder<TodoBinder, Todo>();
 
+
+// This enables MVC's model binders
+builder.Services.AddMvcCore();
+
 var app = builder.Build();
 
 await EnsureDb(app.Services, app.Logger);
@@ -122,6 +126,11 @@ app.MapGet("/wrapped/{id}", (Wrapped<int> id) =>
 
 app.MapGet("/parse/{id}", (Parseable<int> id) =>
     $"Successfully parsed {id.Value} as Parseable<int>!")
+    .WithTags("Examples");
+
+// Using MVC's model binding logic
+app.MapGet("/paged2", (ModelBinder<PagedData> paging) =>
+    $"model: {paging.Model}, valid: {paging.ModelState.IsValid}")
     .WithTags("Examples");
 
 app.MapPost("/model", (Model<Todo> model) =>

--- a/src/MinimalApiPlayground/Properties/ModelBinderOfT.cs
+++ b/src/MinimalApiPlayground/Properties/ModelBinderOfT.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// A brige to support MVC's model binders in minimal APIs. Specify ModelBinder&lt;<typeparamref name="T"/>&gt; in the paramter
+/// of your method trigger the model binding system. This requires registering the model binding services by calling AddControllers/AddMvc.
+/// </summary>
+/// <typeparam name="T">The type to model bind</typeparam>
+public class ModelBinder<T>
+{
+    // This caches the model binding information so we don't need to create one from a factory every time
+    private static readonly ConcurrentDictionary<(ParameterInfo, IModelBinderFactory, IModelMetadataProvider),
+                                                 (IModelBinder, BindingInfo, ModelMetadata)> _cache = new();
+
+    /// <summary>
+    /// The model being bound
+    /// </summary>
+    public T? Model { get; }
+
+    /// <summary>
+    /// The validation information.
+    /// </summary>
+    public ModelStateDictionary ModelState { get; }
+
+    public ModelBinder(T? model, ModelStateDictionary modelState)
+    {
+        Model = model;
+        ModelState = modelState;
+    }
+
+    public void Deconstruct(out T? model, out ModelStateDictionary modelState)
+    {
+        model = Model;
+        modelState = ModelState;
+    }
+
+    public static async ValueTask<ModelBinder<T>> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+        var modelBinderFactory = context.RequestServices.GetRequiredService<IModelBinderFactory>();
+        var modelMetadataProvider = context.RequestServices.GetRequiredService<IModelMetadataProvider>();
+        var parameterBinder = context.RequestServices.GetRequiredService<ParameterBinder>();
+
+        var (binder, bindingInfo, metadata) = _cache.GetOrAdd((parameter, modelBinderFactory, modelMetadataProvider), static arg =>
+        {
+            var (parameter, modelBinderFactory, modelMetadataProvider) = arg;
+
+            ModelMetadata metadata = modelMetadataProvider.GetMetadataForType(typeof(T));
+
+            var bindingInfo = BindingInfo.GetBindingInfo(parameter.GetCustomAttributes(), metadata);
+
+            var binder = modelBinderFactory.CreateBinder(new ModelBinderFactoryContext
+            {
+                BindingInfo = bindingInfo,
+                Metadata = metadata,
+                CacheToken = parameter
+            });
+
+            return (binder!, bindingInfo!, metadata!);
+        });
+
+        // Resolve the value provider factories from MVC options
+        var valueProviderFactories = context.RequestServices.GetRequiredService<IOptions<MvcOptions>>().Value.ValueProviderFactories;
+
+        // We don't have an action descriptor, so just make up a fake one. Custom binders that rely on 
+        // a specific action descriptor (like ControllerActionDescriptor, won't work).
+        var actionContext = new ActionContext(context, context.GetRouteData(), new ActionDescriptor());
+
+        var valueProvider = await CompositeValueProvider.CreateAsync(actionContext, valueProviderFactories);
+        var paramterDescriptor = new ParameterDescriptor
+        {
+            BindingInfo = bindingInfo,
+            Name = parameter.Name!,
+            ParameterType = parameter.ParameterType
+        };
+
+        var result = await parameterBinder.BindModelAsync(actionContext, binder, valueProvider, paramterDescriptor, metadata, value: null, container: null);
+
+        return new ModelBinder<T>((T?)result.Model, actionContext.ModelState);
+    }
+}

--- a/src/MinimalApiPlayground/Properties/PagedData.cs
+++ b/src/MinimalApiPlayground/Properties/PagedData.cs
@@ -1,0 +1,20 @@
+﻿
+using Microsoft.AspNetCore.Mvc;
+
+public class PagedData
+{
+    [FromQuery]
+    public int PageIndex { get; set; }
+
+    [FromQuery]
+    public int PageSize { get; set; }
+
+    [FromQuery]
+    public string? SortBy { get; set; }
+
+    [FromQuery(Name = "sortDir")]
+    public string? SortDirection { get; set; }
+
+    public override string ToString() =>
+        $"{nameof(SortBy)}:{SortBy}, {nameof(SortDirection)}:{SortDirection}, {nameof(PageIndex)}:{PageIndex}, {nameof(PageSize)}:{PageSize}";
+}


### PR DESCRIPTION
- This change adds a ModelBinder<T> type that has a BindAsync that works with minimal APIs. The caller still needs to register MVC's model binder services to make it work but it'll call into the same plumbing to do model binding and will expose the information via 2 properties (or via deconstuction).